### PR TITLE
Time-limited messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,4 +31,4 @@ jobs:
         if: github.repository_owner == 'MiniDigger'
         env:
           HANGAR_API_TOKEN: ${{ secrets.HANGAR_API_TOKEN }}
-        run: ./gradlew publishPlugin --stacktrace
+        run: ./gradlew publishAllPublicationsToHangar --stacktrace

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3-SNAPSHOT
+version=1.4

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,4 +17,5 @@ dont-bug-me: [ ]
 dont-in-worlds: [ ]
 
 # List with messages (now you can use a %player variable)
+# Now you can add the expiration time at the end of the message (e.g. "Hello World;expire:2026-01-01T12:00:00" or "json:[{"text":"Hello World"}];expire:2026-01-01T12:00:00")
 messages: [ ]


### PR DESCRIPTION
Added support for time-limited messages using the string `;expire:yyyy-mm-ddThh:mm:ss` at the end of each message (optional, also applies to json).